### PR TITLE
Fix HTTP links to HTTPS and update Node engine

### DIFF
--- a/cluster.js
+++ b/cluster.js
@@ -776,7 +776,7 @@ else  //workers handle all communication with the clients.
     main.set('port', (process.env.PORT || 5000))
 
     //PASSTHROUGH
-    app.use('/proxy/kiva', proxy('http://www.kiva.org', proxyHandler))
+    app.use('/proxy/kiva', proxy('https://www.kiva.org', proxyHandler))
     app.use('/proxy/gdocs', proxy('https://docs.google.com', proxyHandler))
 
     //app.use(express.static(__dirname + '/public'))

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "xhr2": "^0.1.3"
   },
   "engines": {
-    "node": "5.9.1"
+    "node": "20.x"
   },
   "repository": {
     "type": "git",

--- a/react/src/scripts/api/kivajs/Request.js
+++ b/react/src/scripts/api/kivajs/Request.js
@@ -80,7 +80,7 @@ class Request {
     //fetch data from kiva right now. use sparingly. sem_get makes sure the browser never goes above a certain number of active requests.
     static get(path, params){
         params = extend({}, params, {app_id: api_options.app_id})
-        return getUrl(`http://api.kivaws.org/v1/${path}?${serialize(params)}`,{parseJSON: true}).fail(e => cl(e) )
+        return getUrl(`https://api.kivaws.org/v1/${path}?${serialize(params)}`,{parseJSON: true}).fail(e => cl(e) )
         //can't use the following because this is semaphored... they stack up (could now that there are more options to block semaphore?). return req.kiva.api.get(path, params).fail(e => cl(e) )
     }
 

--- a/react/src/scripts/api/kivajs/req.js
+++ b/react/src/scripts/api/kivajs/req.js
@@ -32,7 +32,7 @@ if (!isServer()) {
 }
 
 req.kiva = {
-    api: new SemRequest('http://api.kivaws.org/v1/',true,false,{app_id: 'org.kiva.kivalens'},2),
+    api: new SemRequest('https://api.kivaws.org/v1/',true,false,{app_id: 'org.kiva.kivalens'},2),
     page: new SemRequest(`${kivaBase}`,false,!isServer(),{},5*60),
     ajax: new SemRequest(`${kivaBase}ajax/`,true,!isServer(),{},5*60)
 }

--- a/react/src/scripts/components/Face.jsx
+++ b/react/src/scripts/components/Face.jsx
@@ -30,9 +30,9 @@ const Face = React.createClass({
     fetchPortfolio(){
         const selectImage = loan => {
             var image_id = loan.image.id
-            var thumb= `http://www.kiva.org/img/w800/${image_id}.jpg`
-            var zoom = thumb //`http://www.kiva.org/img/w800/${image_id}.jpg`
-            var link = `http://www.kiva.org/lend/${loan.id}`
+            var thumb= `https://www.kiva.org/img/w800/${image_id}.jpg`
+            var zoom = thumb //`https://www.kiva.org/img/w800/${image_id}.jpg`
+            var link = `https://www.kiva.org/lend/${loan.id}`
             return {thumb,zoom,link}
         }
         const that = this

--- a/react/src/scripts/components/SnowStack.jsx
+++ b/react/src/scripts/components/SnowStack.jsx
@@ -15,9 +15,9 @@ const SnowStack = React.createClass({
         var that = this
         const selectImage = loan => {
             var image_id = loan.image.id
-            var thumb= `http://www.kiva.org/img/w800/${image_id}.jpg`
-            var zoom = thumb //`http://www.kiva.org/img/w800/${image_id}.jpg`
-            var link = `http://www.kiva.org/lend/${loan.id}`
+            var thumb= `https://www.kiva.org/img/w800/${image_id}.jpg`
+            var zoom = thumb //`https://www.kiva.org/img/w800/${image_id}.jpg`
+            var link = `https://www.kiva.org/lend/${loan.id}`
             //title:loan.name,
             return {thumb,zoom,link}
         }


### PR DESCRIPTION
## Summary
- enforce HTTPS usage for Kiva and KivaLens URLs
- bump Node engine to 20.x for Heroku

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685792f97fa0832081b4a22482cbf35e