### PR TITLE
Wait for RSS filter readiness

### DIFF
--- a/FractalFlow.lssd.md
+++ b/FractalFlow.lssd.md
@@ -247,6 +247,16 @@ truth search.filter_readiness {
   summary: "Tracks pending lender-loan, description-keyword, and enabled portfolio-balancer data only when it can still change the current filtered result list."
 }
 
+truth rss.filter_readiness {
+  label: "RSS filter data readiness"
+  lifetime: request
+  authority: { mode: derived, ref: @kivalens.node_server }
+  visibility: [rss_recipient, system]
+  status: observed
+  confidence: 0.95
+  summary: "A successful RSS response waits for the fully published live server filtering dataset and every lender-loan or portfolio-balancer download required by its active criteria; missing or unavailable prerequisites fail closed without a partial feed."
+}
+
 truth lender.basket {
   label: "Current local basket"
   lifetime: device

--- a/KivaLens_LSSD_Audit_and_Roadmap.md
+++ b/KivaLens_LSSD_Audit_and_Roadmap.md
@@ -47,7 +47,7 @@ audit_counts:
     externalized_catalogs_observed: 6
     pseudo_locale_gate_observed: false
   verification:
-    unit_tests: "128 passed in 15 files"
+    unit_tests: "140 passed in 17 files"
     ai_eval_fixtures: "7 valid in dry mode"
     build: passed
     lint: "new files clean; full legacy gate: 155 errors, 6 warnings"
@@ -66,7 +66,8 @@ Implemented on 2026-07-14:
 - added a seven-case dry/live AI eval harness plus architecture, SSE, storage, and locale tests;
 - added browser-local chatbot memory through the fixed `AskKivaLens:` ApplicationStorage namespace, with safe keys, 32-key/4-KiB limits, and no visibility into unrelated local storage;
 - localized product chrome and displayed sector labels for English, Español, Français, Deutsch, Italiano, and Nederlands while preserving English Kiva sector values for filters/search and keeping loan description/use text in English;
-- implemented on 2026-07-26: centralized active-filter readiness tracking and accessible warnings above loan results and on the Your Portfolio tab for pending lender-loan, description-keyword, and enabled portfolio-balancer data.
+- implemented on 2026-07-26: centralized active-filter readiness tracking and accessible warnings above loan results and on the Your Portfolio tab for pending lender-loan, description-keyword, and enabled portfolio-balancer data;
+- implemented on 2026-07-26: gated successful RSS responses on the fully published live server filtering dataset and every active portfolio dependency; missing lender identity or unavailable required data returns a non-feed 400/503 response instead of a partial RSS artifact.
 
 Explicit product decision: WP-03's universal command proposal/confirmation architecture is declined. Explicitly requested, bounded browser-local actions continue to apply immediately through the existing tool/event path. Existing feature-specific safeguards may remain, but the product will not require confirmation for every chatbot action.
 
@@ -436,7 +437,7 @@ Each answer family needs: allowed actor, data sources, protected exclusions, pro
 | F-03 | accepted decision | Side-effecting browser-local AI tools execute immediately by explicit product choice; no universal registry/preview/confirmation layer is planned. | server/aiChat.mjs + product decision | L21-L23; A4, A16 |
 | F-04 | 1 | The server tells the model a client-side mutation succeeded before the client acknowledges it; abort/SSE failure can split truth. | SSE events + client handlers | L16, L20-L23; S7/S8 |
 | F-05 | 1 | AI abuse/cost controls lack per-client rate/concurrency limits and atomic budget reservation; unknown models use a low fallback price. | aiChat request entry; aiUsage pricing | L23, L39; A16 |
-| F-06 | partially resolved | Seven behavior fixtures and architecture/SSE/storage tests now cover the Responses and ApplicationStorage boundaries; production-derived depth remains future work. | evals/ask-kivalens.json; new tests; 128 tests pass | L42; A16 |
+| F-06 | partially resolved | Seven behavior fixtures and architecture/SSE/storage tests now cover the Responses and ApplicationStorage boundaries; production-derived depth remains future work. | evals/ask-kivalens.json; new tests; 140 tests pass | L42; A16 |
 | F-07 | 1 | Admin secrets are accepted in query strings and a side-effecting digest send uses GET. | server/aiChat.mjs:1355-1400 | L21, L23, L35 |
 | F-08 | scoped resolution | Six locale catalogs now cover core chrome and displayed sectors; descriptions/use intentionally remain English, while pseudo-locale and complete long-form coverage remain deferred. | src/i18n; localized surfaces | L31-L34; G8/A8 |
 | F-09 | resolved | Main is now 333 KB minified / 106 KB gzip; chatbot, charting, and secondary routes are lazy chunks. | npm run build; App.tsx | L2/L3; speed |
@@ -507,6 +508,7 @@ Outcome: first useful results arrive before the entire enrichment corpus.
 - Fetch keyword/description packets in parallel, on idle, or only when full-text features need them.
 - Cache parsed batch data in IndexedDB keyed by batch with explicit staleness.
 - Implemented 2026-07-26: show which active filtering dependencies are still loading, including lender loans, description keywords, and enabled portfolio balancers.
+- Implemented 2026-07-26: hold successful RSS generation until its full live filtering dataset and all criteria-required portfolio data are ready; fail closed rather than publish a partial feed.
 - Remaining: reveal dataset freshness and overall partial completeness; measure first-page usable, full-data ready, main-thread long tasks, and memory.
 
 ### WP-03 — Immediate-action chatbot
@@ -766,10 +768,10 @@ Every slice must include current-locale catalog entries, empty/loading/error/fir
 
 ## 11. Verification evidence
 
-- npm test: 17 files passed, 137 tests passed, including active-filter readiness and portfolio-tab loading notices.
+- npm test: 17 files passed, 140 tests passed, including active-filter UI warnings plus RSS live-dataset waiting, missing-lender rejection, and required-download fail-closed coverage.
 - npm run eval:ai:dry: 7 fixtures valid; no paid API calls.
 - npm run build: passed and generated 39 compressed assets.
-- New filtering-readiness files pass targeted ESLint. Full legacy lint remains tracked separately from this slice.
+- Modified RSS runtime and test files pass targeted ESLint; the declaration file is outside the configured lint match. Full legacy lint remains tracked separately from this slice.
 - Build output:
   - main: 304.66 KB minified / 96.80 KB gzip.
   - eager i18n foundation: 99.43 KB / 35.42 KB gzip.

--- a/server/klCore.d.mts
+++ b/server/klCore.d.mts
@@ -3,6 +3,9 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 /** Mutable server state holding the prepared, batched loan dataset. */
 export interface KLState {
   ready: boolean
+  rssReady: boolean
+  rssReadyPromise: Promise<void>
+  resolveRssReady: () => void
   batch: number
   klStart: unknown
   batches: Map<number, unknown>

--- a/server/klCore.mjs
+++ b/server/klCore.mjs
@@ -38,6 +38,7 @@ const KL_PAGE_SPLITS = 4
 // every 5 min and re-packaged every 60s). One combined cycle is plenty.
 export const REFRESH_INTERVAL_MS = 10 * 60_000
 const RETAINED_BATCHES = 2
+const RSS_READY_TIMEOUT_MS = 25_000
 const KIVA_API = 'https://api.kivaws.org/v1'
 const APP_ID = 'org.kiva.kivalens'
 
@@ -478,8 +479,19 @@ async function loadAplusCsv(log) {
 // ---------------------------------------------------------------------------
 
 export function createState() {
+  let resolveRssReady
+  const rssReadyPromise = new Promise((resolve) => {
+    resolveRssReady = resolve
+  })
+
   return {
     ready: false,
+    // RSS needs the full live loan + partner objects. The Redis warm start only
+    // restores compressed API pages and per-loan details, so general API
+    // readiness must not be treated as RSS filtering readiness.
+    rssReady: false,
+    rssReadyPromise,
+    resolveRssReady,
     batch: 0,
     klStart: null,
     batches: new Map(), // retained batches (latest RETAINED_BATCHES)
@@ -624,6 +636,10 @@ export async function prepareData(state, log = console.log) {
     state.batch = batch
     state.klStart = klStart
     state.ready = true
+    if (!state.rssReady) {
+      state.rssReady = true
+      state.resolveRssReady()
+    }
 
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
     // `processed` is deliberately released above to lower the refresh peak; use
@@ -845,6 +861,30 @@ export function handleRss(state, req, res) {
   return true
 }
 
+async function waitForRssData(state) {
+  if (state.rssReady) return true
+
+  let timeout
+  try {
+    return await Promise.race([
+      state.rssReadyPromise.then(() => true),
+      new Promise((resolve) => {
+        timeout = setTimeout(() => resolve(false), RSS_READY_TIMEOUT_MS)
+      }),
+    ])
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function sendRssUnavailable(res, message) {
+  res.statusCode = 503
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+  res.setHeader('Cache-Control', 'no-store')
+  res.setHeader('Retry-After', '30')
+  res.end(message)
+}
+
 async function serveRssFeed(state, req, res) {
   const url = req.url || ''
   const m = url.match(/^\/rss\/(.+)$/)
@@ -869,20 +909,34 @@ async function serveRssFeed(state, req, res) {
     portfolio: { ...(crit.portfolio || {}) },
   }
 
+  // Portfolio features (exclude-my-loans + balancing) require the lender's data.
+  // Reject an incomplete artifact instead of silently omitting those filters.
+  const lenderId = feed.lender_id ? String(feed.lender_id) : null
+  const needsLenderData =
+    criteria.portfolio.exclude_portfolio_loans === 'true' ||
+    BALANCER_SLICES.some((s) => criteria.portfolio[`pb_${s}`]?.enabled)
+  if (needsLenderData && !lenderId) {
+    res.statusCode = 400
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+    res.setHeader('Cache-Control', 'no-store')
+    res.end('RSS portfolio filters require a lender id')
+    return
+  }
+
+  // General API readiness may come from the compressed Redis warm start. RSS
+  // filtering needs the separately-published live loan and partner objects.
+  if (!state.rssReady && !(await waitForRssData(state))) {
+    sendRssUnavailable(res, 'RSS filter data is still loading; retry shortly')
+    return
+  }
+
   const ctx = {
     loans: state.allLoans,
     activePartners: state.activePartners,
     atheistListProcessed: state.atheistListProcessed,
   }
 
-  // Portfolio features (exclude-my-loans + balancing) require the lender's data,
-  // which we fetch + disk-cache per lender. The lender id rides in feed.lender_id.
-  const lenderId = feed.lender_id ? String(feed.lender_id) : null
-  const wantsLender =
-    lenderId &&
-    (criteria.portfolio.exclude_portfolio_loans === 'true' ||
-      BALANCER_SLICES.some((s) => criteria.portfolio[`pb_${s}`]?.enabled))
-  if (wantsLender) {
+  if (needsLenderData) {
     try {
       const lender = await loadLenderRssData(lenderId, criteria.portfolio, console.log)
       criteria.portfolio = lender.portfolio // pb_<slice>.values now resolved
@@ -891,7 +945,9 @@ async function serveRssFeed(state, req, res) {
         ctx.lenderLoans = { [lenderId]: lender.loanIds }
       }
     } catch (e) {
-      console.error(`RSS lender data failed (serving feed without portfolio): ${e}`)
+      console.error(`RSS required lender data failed: ${e}`)
+      sendRssUnavailable(res, 'RSS portfolio filter data is unavailable; retry shortly')
+      return
     }
   }
 

--- a/server/lenderData.mjs
+++ b/server/lenderData.mjs
@@ -71,7 +71,7 @@ async function fetchLenderLoansPage(lenderId, page, tries = 5) {
   throw lastErr
 }
 
-export async function fetchLenderFundraisingLoanIds(lenderId, log = () => {}) {
+export async function fetchLenderFundraisingLoanIds(lenderId, log = () => {}, options = {}) {
   const key = `lender-loans-${lenderId}`
   const cached = await readCache(key, LENDER_LOANS_TTL_MS)
   if (cached) {
@@ -106,6 +106,7 @@ export async function fetchLenderFundraisingLoanIds(lenderId, log = () => {}) {
         /* ignore */
       }
     }
+    if (options.required) throw e
     return ids
   }
 }
@@ -154,7 +155,7 @@ export async function fetchLenderProfile(lenderId, log = () => {}) {
   }
 }
 
-export async function fetchSuperGraphSlices(lenderId, sliceBy, include = 'all', log = () => {}) {
+export async function fetchSuperGraphSlices(lenderId, sliceBy, include = 'all', log = () => {}, options = {}) {
   const key = `lender-sg-${lenderId}-${sliceBy}-${include}`
   const cached = await readCache(key, SUPERGRAPH_TTL_MS)
   if (cached) {
@@ -196,6 +197,7 @@ export async function fetchSuperGraphSlices(lenderId, sliceBy, include = 'all', 
         /* ignore */
       }
     }
+    if (options.required) throw e
     return []
   }
 }
@@ -220,14 +222,16 @@ export function resolveBalancerValues(config, slices, sliceBy) {
  *   - portfolio: a copy of the input with each enabled pb_<slice>'s `values`
  *     resolved from the lender's live distribution.
  * Fetches run concurrently; each piece is independently disk-cached, so a static
- * RSS URL stays fresh without re-fetching every request.
+ * RSS URL stays fresh without re-fetching every request. Every requested piece is
+ * strict here: if neither a live response nor stale cache is available, reject so
+ * the caller cannot publish a partially filtered feed.
  */
 export async function loadLenderRssData(lenderId, portfolio, log = () => {}) {
   const result = { lenderId, loanIds: [], portfolio: { ...portfolio } }
   const tasks = []
   if (portfolio.exclude_portfolio_loans === 'true') {
     tasks.push(
-      fetchLenderFundraisingLoanIds(lenderId, log).then((ids) => {
+      fetchLenderFundraisingLoanIds(lenderId, log, { required: true }).then((ids) => {
         result.loanIds = ids
       }),
     )
@@ -236,7 +240,7 @@ export async function loadLenderRssData(lenderId, portfolio, log = () => {}) {
     const cfg = portfolio[`pb_${slice}`]
     if (cfg?.enabled) {
       tasks.push(
-        fetchSuperGraphSlices(lenderId, slice, cfg.allactive ?? 'all', log).then((slices) => {
+        fetchSuperGraphSlices(lenderId, slice, cfg.allactive ?? 'all', log, { required: true }).then((slices) => {
           result.portfolio[`pb_${slice}`] = { ...cfg, values: resolveBalancerValues(cfg, slices, slice) }
         }),
       )

--- a/src/lib/rss.test.ts
+++ b/src/lib/rss.test.ts
@@ -1,17 +1,25 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 // handleRss is plain JS in klCore; createState gives a baseline server state.
 import { handleRss, createState } from '../../server/klCore.mjs'
 
 function mockRes() {
+  let finish!: () => void
+  const done = new Promise<void>((resolve) => {
+    finish = resolve
+  })
   return {
     statusCode: 0,
     headers: {} as Record<string, string>,
     body: '',
+    ended: false,
+    done,
     setHeader(k: string, v: string) {
       this.headers[k.toLowerCase()] = v
     },
     end(b?: string) {
       this.body = b ?? ''
+      this.ended = true
+      finish()
     },
   }
 }
@@ -39,6 +47,7 @@ const mkLoan = (o: Record<string, unknown>) => ({
 
 const state = {
   ...createState(),
+  rssReady: true,
   allLoans: [
     mkLoan({ id: 1, sector: 'Agriculture', partner_id: 10, name: 'Aisha' }),
     mkLoan({ id: 2, sector: 'Retail', partner_id: 20, name: 'Bao & Co <Ltd>' }),
@@ -56,6 +65,10 @@ const call = (url: string) => {
   return { handled, res }
 }
 const feedUrl = (crit: object) => '/rss/' + encodeURIComponent(JSON.stringify(crit))
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('handleRss feed', () => {
   it('returns valid RSS 2.0 with the right content-type and items', () => {
@@ -82,6 +95,60 @@ describe('handleRss feed', () => {
     expect(res.body).toContain('<title>Aisha</title>')
     expect(res.body).not.toContain('Bao')
     expect(res.body).toContain('rss_click/kivalens/1')
+  })
+
+  it('waits for the full live RSS dataset before ending the response', async () => {
+    let release!: () => void
+    const waitingState = {
+      ...state,
+      rssReady: false,
+      rssReadyPromise: new Promise<void>((resolve) => {
+        release = resolve
+      }),
+    }
+    const res = mockRes()
+
+    expect(
+      handleRss(
+        waitingState,
+        { url: feedUrl({ feed: { name: 'Waiting' } }), headers: { host: 'www.kivalens.org' } },
+        res,
+      ),
+    ).toBe(true)
+    await Promise.resolve()
+    expect(res.ended).toBe(false)
+
+    waitingState.rssReady = true
+    release()
+    await res.done
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toContain('<title>Waiting</title>')
+  })
+
+  it('rejects active portfolio filters without a lender id', () => {
+    const { res } = call(
+      feedUrl({
+        feed: { name: 'Portfolio' },
+        portfolio: { pb_sector: { enabled: true, percent: 10, ltgt: 'lt' } },
+      }),
+    )
+    expect(res.statusCode).toBe(400)
+    expect(res.body).not.toContain('<rss')
+  })
+
+  it('fails closed when a required portfolio download is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+    const { res } = call(
+      feedUrl({
+        feed: { name: 'Portfolio', lender_id: `rss-readiness-${Date.now()}` },
+        portfolio: { pb_sector: { enabled: true, percent: 10, ltgt: 'lt' } },
+      }),
+    )
+
+    await res.done
+    expect(res.statusCode).toBe(503)
+    expect(res.headers['retry-after']).toBe('30')
+    expect(res.body).not.toContain('<rss')
   })
 
   it('returns 400 on malformed criteria', () => {


### PR DESCRIPTION
## What changed

- added an RSS-specific readiness gate that waits for the full live loan and partner objects instead of treating the compressed Redis warm start as filter-ready
- kept successful RSS generation pending until every lender-loan and enabled portfolio-balancer dependency required by the feed criteria finishes
- rejects portfolio criteria without a lender ID and returns a retryable 503 when required portfolio data is unavailable, rather than emitting a partial feed
- documented the RSS readiness truth in the active FractalFlow contract and audit

## Why

The warm-start cache marks the general data API ready but restores only compressed pages and per-loan detail records. RSS filtering uses the full server-side loan and partner objects, so a request during startup could emit an empty or partially filtered feed. Required portfolio fetch failures were also degraded to empty values and the feed was still served.

## Impact

A 200 RSS response now means all data required by its active criteria was available and applied. Requests wait up to the server readiness window, then return a non-cacheable 503 with `Retry-After` instead of publishing incomplete results. Invalid portfolio feed URLs without a lender ID return 400.

## Validation

- `npm test` — 17 files, 140 tests passed
- RSS suite — 10 tests passed, including wait, missing-lender, and fail-closed cases
- `npm run build` — passed; 39 assets compressed
- targeted ESLint — no errors (declaration file is outside the configured match)
- `git diff --check` — passed
- LSSD contract check — clean